### PR TITLE
default value for $HOME when adding the application user

### DIFF
--- a/.s2i/bin/assemble
+++ b/.s2i/bin/assemble
@@ -53,6 +53,7 @@ ln -s /opt/app-root/bin/wait-for-database /opt/app-root/scripts/wait-for-databas
 
 # Ensure passwd/group file intercept happens for any shell environment.
 
+echo "HOME=\${HOME:-$HOME}" >> /opt/app-root/etc/scl_enable
 echo "source /opt/app-root/etc/generate_container_user" >> /opt/app-root/etc/scl_enable
 
 # Create additional directories.


### PR DESCRIPTION
The base image (`centos/python-36-centos7`) uses `/opt/app-root/etc/passwd` instead of the system's `/etc/passwd` file. When this file is updated to contain the default application user (by sourcing `/opt/app-root/etc/generate_container_user`), the `$HOME` environment variable is used the specify the home directory:
https://github.com/sclorg/s2i-python-container/blob/1ff8621371c9c6c39cadea5e18cf0b6a2275a949/3.6/root/opt/app-root/etc/generate_container_user#L12

Some scripts (for example `cull-idle-servers`) indirectly source this file:
https://github.com/jupyter-on-openshift/jupyterhub-quickstart/blob/e5c38ddea76c8f5689c776bdc898e037a5b2e66a/.s2i/bin/assemble#L56
https://github.com/jupyter-on-openshift/jupyterhub-quickstart/blob/e5c38ddea76c8f5689c776bdc898e037a5b2e66a/scripts/cull-idle-servers#L3

However, JupyterHub services are started in a rather minimal environment:
https://github.com/jupyterhub/jupyterhub/blob/e4d4e059bd6ecc749a6276a80eada8f0de8ad206/jupyterhub/services/service.py#L317

This results in `$HOME` not being set and the user having no home directory after the service is executed. For applications relying on the `passwd` file to get the user's home directory afterwards, this can lead to problems.

As an example, `ssh` defaults to the root directory to create the `.ssh` directory in case the home directory is not set:
https://github.com/openssh/openssh-portable/blob/4d28fa78abce2890e136281950633fae2066cc29/ssh.c#L1427
Non-root users have no write permissions there and the execution fails.

With this merge request I make sure that `$HOME` is set in the `/opt/app-root/etc/scl_enable` script before sourcing `/opt/app-root/etc/generate_container_user`. Please let me know in case there is a better place to add this.
