### PR TITLE
Bump postgresql version to 9.6-el8 tag

### DIFF
--- a/templates/jupyterhub-deployer.json
+++ b/templates/jupyterhub-deployer.json
@@ -437,7 +437,7 @@
                             ],
                             "from": {
                                 "kind": "ImageStreamTag",
-                                "name": "postgresql:9.6",
+                                "name": "postgresql:9.6-el8",
                                 "namespace": "openshift"
                             }
                         },


### PR DESCRIPTION
Fixes https://github.com/openshift-labs/learn-katacoda/issues/1244